### PR TITLE
Create Kafka image for Ubuntu based signalboost

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
-# Dockerfile for Alpine-based Kafka
+# Dockerfile for Ubuntu-based Kafka
 
-FROM quay.io/signalfuse/maestro-base:alp-3.4-jdk8
-MAINTAINER Maxime Petazzoni <max@signalfx.com>
+FROM quay.io/signalfuse/maestro-base:ubuntu-16.10-jdk8
+MAINTAINER Janet Yu <jwy@signalfx.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 Kafka on Docker
 ===============
 
-This `Dockerfile` creates a Docker image that can be used as the base for
-running Kafka within a Docker container. The Kafka service is ran by the run.sh
-script which is in charge of setting up the Kafka configuration from
+`Dockerfile` creates an Alpine Linux-based Docker image that can be used as the
+base for running Kafka within a Docker container. The Kafka service is ran by
+the run.sh script which is in charge of setting up the Kafka configuration from
 environment variables passed to the container when it is run.
 
 The version of Kafka is defined in the `Dockerfile` and currently points at the
 last available beta release.
+
+Similarly, `Dockerfile.ubuntu` creates an Ubuntu-based Docker image that can be
+used as the Kafka base.
 
 Environment variables
 ---------------------

--- a/install_kafka
+++ b/install_kafka
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -e
+set -x
+
+# Get Python ZooKeeper (Kazoo)
+pip install kazoo
+
+# Git user config for cherry-pick to work
+git config --global user.email "max@signalfx.com"
+git config --global user.name "Maxime Petazzoni"
+
+# Gradle - required to build kafka
+export GRADLE_VERSION=2.6
+mkdir -p /opt/gradle-${GRADLE_VERSION}
+cd /opt/gradle-${GRADLE_VERSION}
+curl -jkssL "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" -o gradle-${GRADLE_VERSION}-bin.zip
+unzip "gradle-${GRADLE_VERSION}-bin.zip"
+ln -s "gradle-${GRADLE_VERSION}" gradle
+rm "gradle-${GRADLE_VERSION}-bin.zip"
+
+# Get Kafka 0.8.2.1 but cherry-pick the commit that uses zk client 0.5 since it
+# is supposed to fix some bugs.
+export PATH=$PATH:/opt/gradle-${GRADLE_VERSION}/gradle/bin
+mkdir -p /opt
+git clone https://github.com/apache/kafka.git /opt/kafka
+cd /opt/kafka
+git checkout -b blessed tags/0.8.2.1
+git cherry-pick 41ba26273b497e4cbcc947c742ff6831b7320152
+gradle
+sed -i "s/gradle-2\.0/gradle-${GRADLE_VERSION}/" gradle/wrapper/gradle-wrapper.properties
+./gradlew jar


### PR DESCRIPTION
New Dockerfile to create Ubuntu based Kafka image for Ubuntu based signalboost.
Refactored common commands from the Dockerfiles into a separate script.