### PR TITLE
Fixes for 0.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN pip install kazoo
 ENV KAFKA_VERSION 0.10.2.0
 RUN wget https://apache.osuosl.org/kafka/${KAFKA_VERSION}/kafka_2.10-${KAFKA_VERSION}.tgz -O /tmp/kafka_2.10-{KAFKA_VERSION}.tgz \
     && tar xfz /tmp/kafka_2.10-{KAFKA_VERSION}.tgz -C /opt \
-    && rm /tmp/kafka_2.10-{KAFKA_VERSION}.tgz
+    && rm /tmp/kafka_2.10-{KAFKA_VERSION}.tgz \
+    && ln -s /opt/kafka_2.10-${KAFKA_VERSION} /opt/kafka
 
 ADD run.py /opt/kafka/.docker/
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ seed the service's configuration:
   - `CONTAINER_HOST_ADDRESS` should contain the address of the Docker
     container's host. It' used by Kafka as the address advertised to ZooKeeper
     for broker discovery and is required for the container to start;
+  - `KAFKA_PROTOCOL_VERSION` should contain the Kafka protocol version to use;
+  - `KAFKA_LOG_VERSION` should contain the Kafka log message version to use;
 
   - `ZOOKEEPER_BASE`, the ZooKeeper tree chroot for Kafka to use in the
     `zookeeper.connect` string and properly namespace the Kafka zNodes

--- a/run.py
+++ b/run.py
@@ -28,7 +28,8 @@ KAFKA_CONFIG_FILE = os.path.join('config', 'server.properties')
 KAFKA_LOGGING_CONFIG = os.path.join('config', 'log4j.properties')
 KAFKA_ZOOKEEPER_BASE = os.environ.get('ZOOKEEPER_BASE',
                                       '/{}/kafka'.format(get_environment_name()))
-KAFKA_PROTOCOL_VERSION = os.environ.get('KAFKA_PROTOCOL_VERSION', '0.8.2.X')
+KAFKA_PROTOCOL_VERSION = os.environ['KAFKA_PROTOCOL_VERSION']
+KAFKA_LOG_VERSION = os.environ['KAFKA_LOG_VERSION']
 
 LOG_PATTERN = "%d{yyyy'-'MM'-'dd'T'HH:mm:ss.SSSXXX} %-5p [%-35.35t] [%-36.36c]: %m%n"
 
@@ -84,6 +85,7 @@ kafka.csv.metrics.dir=/var/lib/kafka/metrics/
 kafka.csv.metrics.reporter.enabled=false
 
 inter.broker.protocol.version=%(kafka_protocol_version)s
+log.message.format.version=%(kafka_log_version)s
 
 delete.topic.enable=true
 """
@@ -119,6 +121,7 @@ config_model = {
     'log_roll_hours': int(os.environ.get('LOG_ROLL_HOURS', 24 * 7)),
     'zookeeper_nodes': ZOOKEEPER_NODE_LIST,
     'zookeeper_base': KAFKA_ZOOKEEPER_BASE,
+    'kafka_log_version': KAFKA_LOG_VERSION,
     'kafka_protocol_version': KAFKA_PROTOCOL_VERSION,
     'flush_interval_ms': int(os.environ.get('FLUSH_INTERVAL_MS', 10000)),
     'flush_interval_msgs': int(os.environ.get('FLUSH_INTERVAL_MSGS', 10000)),


### PR DESCRIPTION
* Add ability to specify KAFKA_LOG_VERSION which will be needed for 0.10 transition
* Make KAFKA_PROTOCOL_VERSION and KAFKA_LOG_VERSION require an explicit setting
* Add link of /opt/kafka to the extracted kafka directory so the working directory is correct